### PR TITLE
enh: fallback on tags if available

### DIFF
--- a/etserver/__init__.py
+++ b/etserver/__init__.py
@@ -9,4 +9,5 @@ CACHEDIR = Path(
 )
 CACHEDIR.mkdir(parents=True, exist_ok=True)
 
-GITHUB_API_URL = 'https://api.github.com/repos/{}/releases/latest'
+GITHUB_RELEASE_URL = 'https://api.github.com/repos/{}/releases/latest'
+GITHUB_TAG_URL = 'https://api.github.com/repos/{}/tags'

--- a/etserver/getters.py
+++ b/etserver/getters.py
@@ -1,4 +1,4 @@
-from . import GITHUB_API_URL
+from . import GITHUB_RELEASE_URL, GITHUB_TAG_URL
 from .utils import write_cache
 
 
@@ -13,9 +13,19 @@ async def fetch_version(app, owner, repo):
     """Query GitHub API and write to cache"""
     project = "/".join((owner, repo))
     status, resp = await fetch_response(
-        app, GITHUB_API_URL.format(project)
+        app, GITHUB_RELEASE_URL.format(project)
     )
-    vtag = resp.get('tag_name')
+    # check for tag if no release is found
+    if status == 404:
+        status, resp = await fetch_response(
+            app, GITHUB_TAG_URL.format(project)
+        )
+        try:
+            resp = resp[0]  # latest tag
+        except (KeyError, IndexError):
+            pass
+
+    vtag = resp.get('tag_name') or resp.get('name')
     if not vtag:
         return status, None
     vtag = vtag.lstrip('v')

--- a/etserver/getters.py
+++ b/etserver/getters.py
@@ -1,4 +1,4 @@
-from . import GITHUB_RELEASE_URL, GITHUB_TAG_URL
+from . import GITHUB_RELEASE_URL, GITHUB_TAG_URL, logger
 from .utils import write_cache
 
 
@@ -17,6 +17,7 @@ async def fetch_version(app, owner, repo):
     )
     # check for tag if no release is found
     if status == 404:
+        logger.info(f"No release found for {project}, checking tags...")
         status, resp = await fetch_response(
             app, GITHUB_TAG_URL.format(project)
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ _REQUIRES = [
 ]
 
 setup(
-    name="etelemetry",
+    name="etserver",
     author="Mathias Goncalves",
     version="0.0.1dev0",
     packages=find_packages(),


### PR DESCRIPTION
Closes #8, #9.

Annotated tags do not simulate releasing through GitHub API, so this adds a secondary request to the repo's `/tags`.

Other changes were snuck in:
 - do not require `ETELEMETRY_APP_CONFIG` envvar
 - increase number of concurrent requests
 - add error messages on exit
 - rename package to `etserver` to not conflict with the client.